### PR TITLE
options, ability to validate on empty, async validation of entire form

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,11 @@ validate(form)
 
 ### #validate(callback)
   
-  Validate the form manually and `callback(valid)`.
+  Validate the form manually and `callback(err, valid, msg)` as soon as an invalid form is found.
+
+### #validateAll(callback)
+  
+  Validate the form manually and `callback(err, valid, fields)` when the entire forms status is determined.
 
 ### #value(fn)
   

--- a/component.json
+++ b/component.json
@@ -32,8 +32,10 @@
     "segmentio/is-url": "0.1.0",
     "segmentio/submit-form": "0.0.1",
     "segmentio/validator": "0.0.9",
+    "segmentio/extend": "0.0.1",
     "yields/prevent": "0.0.2",
-    "yields/stop": "0.0.2"
+    "yields/stop": "0.0.2",
+    "paulmillr/async-each": "*"
   },
   "development": {
     "component/assert": "*",

--- a/lib/field.js
+++ b/lib/field.js
@@ -22,8 +22,9 @@ module.exports = Field;
  * @param {Object} validators
  */
 
-function Field (el, adapter, validators) {
+function Field (el, adapter, validators, opts) {
   this.el = el;
+  this.opts = opts;
   this.adapter = adapter;
   this.validators = validators;
   this._validator = new Validator().optional();
@@ -93,8 +94,8 @@ Field.prototype.validate = function (callback) {
 Field.prototype.on = function (event) {
   var self = this;
   bind(this.el, event, function (e) {
-    // don't validate an empty input on blur, that's annoying
-    if ('blur' === event && !self.adapter.value(self.el)) return;
+    // don't validate an empty input on blur, that's annoying - unless you prefer it...
+    if ('blur' === event && !self.adapter.value(self.el) && !self.opts.validateEmpty) return;
     self.validate();
   });
   return this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,9 @@ var adapter = require('./adapter');
 var bind = require('bind');
 var event = require('event');
 var clone = require('clone');
+var each = require('each');
+var async = require('async-each');
+var extend = require('extend');
 var Field = require('./field');
 var submit = require('submit-form');
 var Vldtr = require('validator');
@@ -24,7 +27,9 @@ module.exports = exports = Validator;
 
 function Validator (form) {
   if (!(this instanceof Validator)) return new Validator(form);
+  this.opts = { validateEmpty: false };
   this.form = form;
+  this._fields = [];
   this._validator = new Vldtr();
   this.adapter = clone(adapter);
   this.validators = clone(validators);
@@ -45,6 +50,20 @@ Validator.prototype.use = function (plugin) {
   return this;
 };
 
+
+/**
+ * Set an option
+ * @param {String} key
+ * @param {Any} value
+ */
+
+Validator.prototype.set = function(key, val) {
+  var opts = {};
+  if('object' === typeof key) opts = key;
+  if('string' === typeof key && 'undefined' !== typeof val) opts[key] = val;
+  this.opts = extend(this.opts, opts);
+  return this;
+};
 
 /**
  * Set an aditional trigger `event` for individual field validation.
@@ -68,7 +87,7 @@ Validator.prototype.on = function (event) {
 
 Validator.prototype.field = function (el) {
   if ('string' === typeof el) el = this.form.querySelector('[name="' + el + '"]');
-  var field = new Field(el, this.adapter, this.validators);
+  var field = new Field(el, this.adapter, this.validators, this.opts);
   if (this._event) field.on(this._event);
 
   this._validator.rule(function (val, done) {
@@ -81,12 +100,14 @@ Validator.prototype.field = function (el) {
     return this;
   };
 
+  this._fields.push(field);
+
   return this;
 };
 
 
 /**
- * Validate each field and `callback(valid)`.
+ * Validate each field and `callback(err, valid, msg)` once first field fails.
  *
  * @param {Function} callback
  * @return {Validator}
@@ -96,6 +117,39 @@ Validator.prototype.validate = function (callback) {
   this._validator.validate(null, function (err, valid, msg) {
     callback && callback(err, valid, msg);
   });
+  return this;
+};
+
+/**
+ * Validate each field and `callback(err, valid, fields)`.
+ *
+ * @param {Function} callback
+ * @return {Validator}
+ */
+
+Validator.prototype.validateAll = function (callback) {
+
+  var state = true, errs = [], msgs = [];
+  async(this._fields, validate, status);
+
+  function validate(field, next) {
+    field.validate(function(err, valid, msg) {
+      next(err, {valid: valid, msg: msg });
+    });
+  }
+
+  function status(err, fields) {
+    callback(err, verify(fields), fields);
+  }
+
+  function verify(fields) {
+    var state = true;
+    each(fields, function(f) {
+      if(!f.valid) state = false;
+    });
+    return state;
+  }
+
   return this;
 };
 


### PR DESCRIPTION
As per a brief [exchange](https://twitter.com/slajax/status/436210173946781696) with @ianstormtaylor on twitter, I was looking for a way to have validate-form async validate all form fields when a user clicks submit. 

The need for this behaviour was mostly emphasized by the assumption that empty inputs shouldn't be validated on blur. This was resulting in a user experience that required users to do a lot of back and forth to validate a long form as empty or missed inputs don't get validated on blur whatsoever.

I optimized a few things for these situations:
- Added `set(opts)` method to allow for behaviour modifications without affecting compatibility. Example:

``` javascript
validate
  .set('validateEmpty', true)
    .field('input')
    ..is(...)

validate
  .set({ validateEmpty: true});
    .field('input')
    .is(...)
```

This should allow for more options to be added fairly easily.
- Added `validateAll(fn)` so that onclick of a form you can validate all the form fields and receive back the complete state of the form along with each field's individual state, then XHR should you need to.

``` javascript
form.validateAll(function(err, valid, fields) {
  if(!valid) return doError()
  else sendXHR();
});
```

I felt this approach would be best since it doesn't affect compatibility but provides the desired result as new functionality. There was one wait test that seems to be failing, but I believe it already was. Let me know if there is anything you'd like to see different. 

Thanks for this repo, I really like it.
