### PR TITLE
Some small enhancements

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -54,7 +54,7 @@ Field.prototype.is = function (fn) {
   if ('string' == type(fn)) fn = this.validators[fn];
 
   // handle fns that take settings
-  if (settings.length) fn = fn.apply(null, settings);
+  if (settings.length) fn = fn.apply(this, settings);
 
   this._validator.rule(fn, message);
   return this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,7 @@ Validator.prototype.validate = function (callback) {
  *
  * @param {String|Object} name
  * @param {Function} fn
+ * @return {Validator}
  */
 
 Validator.prototype.validator = function (name, fn) {
@@ -114,6 +115,7 @@ Validator.prototype.validator = function (name, fn) {
   }
 
   this.validators[name] = fn;
+  return this;
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,6 +194,8 @@ Validator.prototype.clear = function (fn) {
 Validator.prototype.bind = function () {
   // capture to preempt other handlers
   event.bind(this.form, 'submit', this.submit, true);
+  // prevent the browser from validating for us
+  this.form.setAttribute('novalidate', true);
   return this;
 };
 
@@ -208,6 +210,8 @@ Validator.prototype.bind = function () {
 Validator.prototype.unbind = function () {
   // capture to preempt other handlers
   event.unbind(this.form, 'submit', this.submit, true);
+  // enable browser form validation
+  this.form.removeAttribute('novalidate');
   return this;
 };
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -4,6 +4,7 @@ var hex = require('is-hex-color');
 var hsl = require('is-hsl-color');
 var rgb = require('is-rgb-color');
 var trim = require('trim');
+var type = require('type');
 var url = require('is-url');
 
 
@@ -11,7 +12,9 @@ var url = require('is-url');
  * Required.
  */
 
-exports.required = trim;
+exports.required = function (val) {
+  return type(val) === 'string' ? trim(val) : val;
+};
 
 
 /**


### PR DESCRIPTION
- Allowing `Validator#validator(name, fn)` to be chainable
- Setting `Field` as the context for a validator function generator
- Allowing `required` fn to take non-strings (checkboxes return `Boolean`, breaking `trim()`)
- Adding `novalidate` to the `<form>` to prevent browser validation from clashing w/ this lib (but still allowing it in case a client-side script doesn't run)

Regarding the 2nd enhancement, this allowed me to create a `equal` validator fn. (checking that 2 fields are equal, like confirm email/password) Without some sort of context I could hook into, I could only make this happen via closure.

I've got other ideas, and I'll likely be submitting several more PRs along the way. :)
