### PR TITLE
Equal Validator

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,7 +3,7 @@
 ----------------------
 * change `#validator` to be chainable
 * change `required` validator to handle non-strings
-* remove `novalidate` attribute from forms
+* add `novalidate` attribute to forms upon bind
 * call validators with `Field` as context
 
 0.8.2 - December 10, 2013

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
     $ component install segmentio/validate-form
 
 ## Example
-  
+
 ```js
 var validate = require('validate-form');
 var form = document.getElementById('#form');
@@ -29,15 +29,15 @@ validate(form)
 ## API
 
 ### validate(el)
-  
+
   Create a new validator for a given form `el`.
 
 ### #field(name)
-  
+
   Add a field to the validator by its `name` attribute. You can also just pass the input `el` directly.
 
 ### #is(fn, [message])
-  
+
   Add a validation `fn` with an optional error `message`.
 
 ### #is(string, [message])
@@ -45,7 +45,7 @@ validate(form)
   Add a validation function by its shorthand `string` with an optional error `message`.
 
 ### #is(regexp, [message])
-  
+
   Add a validation `regexp` with an optional error `message`.
 
 ### #is(string, settings..., [message])
@@ -57,19 +57,19 @@ validate(form)
   Trigger the validation on an `event` in addition to `submit`. For example `'blur'`.
 
 ### #validate(callback)
-  
-  Validate the form manually and `callback(valid)`.
+
+  Validate the form manually and `callback(err, valid, msg)`.
 
 ### #value(fn)
-  
+
   Set the value adapter `fn`, for retrieving the value of the element being validated. By default it will use `component/value`.
 
 ### #invalid(fn)
-  
+
   Set the invalid adapter `fn`, for marking the element as invalid. By default this will add an `invalid` class to the element and append a message `label` element.
 
 ### #valid(fn)
-  
+
   Set the valid adapter `fn`, for marking the element as valid. By default, this will remove an `invalid` class and any message elements.
 
 ## Shorthands
@@ -84,6 +84,7 @@ validate(form)
   * `'hsl'` - requires an HSL color string.
   * `'minimum', length`  - requires a minimum `length` of characters. (also `min`)
   * `'maximum', length` - requires a maximum `length` of characters. (also `max`)
+  * `'equal', other` - requires that this field has the same value as `other` field
 
 ## License
 

--- a/lib/field.js
+++ b/lib/field.js
@@ -22,12 +22,14 @@ module.exports = Field;
  * @param {Object} validators
  */
 
-function Field (el, adapter, validators) {
+function Field (el, validator) {
   this.el = el;
-  this.adapter = adapter;
-  this.validators = validators;
+  this.validator = validator;
+  this.adapter = validator.adapter;
+  this.validators = validator.validators;
   this._validator = new Validator().optional();
   this._valid = true;
+  this.form = validator.form;
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ Validator.prototype.on = function (event) {
 
 Validator.prototype.field = function (el) {
   if ('string' === typeof el) el = this.form.querySelector('[name="' + el + '"]');
-  var field = new Field(el, this.adapter, this.validators);
+  var field = new Field(el, this);
   if (this._event) field.on(this._event);
 
   this._validator.rule(function (val, done) {

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -114,3 +114,25 @@ exports.maximum = function (length) {
     return l <= length;
   };
 };
+
+
+/**
+ * Validation rule that requires 1 field be equal to another
+ *
+ * When a string is used, it will search for an input element with that name.
+ * Otherwise, it's assumed to be something that field.adapter.value will
+ * recognize
+ *
+ * @param {String|mixed} other
+ * @returns {Function}
+ */
+
+exports.equal = function (other) {
+    var field = this;
+    return function (val) {
+      if (type(other) === 'string') {
+        var el = field.form.querySelector("[name=\"" + other + "\"]");
+      }
+      return val === field.adapter.value(el || other);
+    };
+};

--- a/test/validators.js
+++ b/test/validators.js
@@ -379,4 +379,24 @@ describe('validators', function () {
     });
   });
 
+  describe.skip('equal', function () {
+    it('should fail for different values', function (done) {
+      this.input.value = 'a';
+
+      var other = document.createElement('input');
+      other.value = 'b';
+      other.name = 'input2';
+      this.form.appendChild(other);
+
+      this.validator
+        .field('input')
+        .is('equal', 'input2', '')
+        .validate(function (err, valid) {
+          if (err) return done(err);
+          assert(false === valid);
+          done();
+        });
+    });
+  });
+
 });


### PR DESCRIPTION
I've added an "equal" validator, which basically validates that a field has the same value as another field. (like "confirm email" or "confirm password") I've added docs and a test as well.

The biggest change was that I allowed `Field` to accept the parent `Validator` as a param. I was wanting to get a reference to `Validator#form` so I didn't need to use `closest` to traverse up and back down. It made sense to just pass 1 argument and extrapolate from there.

Also updated the history to be a bit more accurate.

Lastly, there is 1 failing test, but it looks like it is for a feature that was never coded? (async validators, that is)
