### PR TITLE
Remove next-tick dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -32,7 +32,7 @@
     "segmentio/is-url": "0.1.0",
     "segmentio/is-domain": "0.0.1",
     "segmentio/submit-form": "0.0.1",
-    "segmentio/validator": "0.0.9",
+    "segmentio/validator": "0.0.13",
     "yields/prevent": "0.0.2",
     "yields/stop": "0.0.2"
   },


### PR DESCRIPTION
The `segmentio/validator` dependency is an old version which still uses next-tick. This version prevented simple use cases where `.validate()` is used synchronously, so I've updated to the latest. I realize it's easy enough to add async validators and break this use case, but it's still convenient.

Here's a simple use case:

``` javascript
function is_valid_email() {
  success = false;
  email_validator.validate(function (err, is_valid, reason) {
    if (!err && is_valid) {
      success = true;
    }
  }); // Looks async, but everything is synchronous
  return success;
}
```
